### PR TITLE
Add Playwright-based padel checker and GitHub Actions workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,7 +2,7 @@ name: Padel Watcher
 
 on:
   schedule:
-    - cron: "*/10 * * * *"   # every 10 minutes
+    - cron: "*/10 * * * *"
   workflow_dispatch: {}
 
 jobs:
@@ -22,11 +22,15 @@ jobs:
           pip install playwright requests
           python -m playwright install --with-deps chromium
 
+      - name: (debug) show files
+        run: |
+          pwd
+          ls -la
+
       - name: Check padel timetable (Playwright)
         env:
           TG_TOKEN:   ${{ secrets.TG_TOKEN }}
-          TG_CHAT_ID: ${{ secrets.TG_CHAT_ID }}   # can be multiple, comma/semicolon separated
-          # --- Filters ---
+          TG_CHAT_ID: ${{ secrets.TG_CHAT_ID }}
           EARLIEST_HOUR: "18"
           LATEST_HOUR:   "22"
           DAYS_AHEAD:    "2"


### PR DESCRIPTION
## Summary
- add Playwright script to check Triangle padel slots and send Telegram alerts
- schedule GitHub Actions workflow every 10 minutes to run the checker
- refactor card text extraction to avoid indentation issues

## Testing
- `python -m py_compile checker_pw.py`


------
https://chatgpt.com/codex/tasks/task_e_68acb8eeb0c48328a2012768abd6c5ac